### PR TITLE
chore(ci): improve build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "rm -rf public && tsc --outDir public",
+    "build": "rm -rf public && tsc --outDir public && rm -rf public/test && rm public/select/*.test.* && mv public/select/* public && rm -rf public/select",
     "test": "jest --config=./test/jest.config.js"
   },
   "dependencies": {


### PR DESCRIPTION
As my PR was accidentally merged (😆 ), this line was missing:

It improves the folder structure after `tsc` finishes the build process, removing unnecessary files and moving the `select` folder content to `public` root.

After:
![image](https://user-images.githubusercontent.com/35051593/96292323-8b968600-0fbf-11eb-829a-1fabde3c547d.png)

Now:
![image](https://user-images.githubusercontent.com/35051593/96292433-9c46fc00-0fbf-11eb-8b2e-08c1dc28f401.png)

Less files = Less bundle size = ❤️ 